### PR TITLE
feat: Implement Affinity Deconstructor modal

### DIFF
--- a/modules/omega_logic.py
+++ b/modules/omega_logic.py
@@ -271,3 +271,67 @@ def adjust_to_omega(user_combo):
         closest_combo = db.find_closest_omega(user_combo, matches)
         if closest_combo: return closest_combo, matches
     return None, 0
+
+def deconstruct_affinity(combination: list) -> dict:
+    """
+    Deconstructs a combination's affinity scores into their constituent subsequences and their frequencies.
+
+    Args:
+        combination (list): A list of 6 integers.
+
+    Returns:
+        dict: A dictionary containing the detailed breakdown of affinity scores, or an error dict.
+    """
+    freqs = get_frequencies()
+    if not freqs:
+        return {"error": "Frecuencias no disponibles."}
+
+    # Use evaluate_combination to get score and totals
+    eval_result = evaluate_combination(combination, freqs)
+    if eval_result.get("error"):
+        return eval_result
+
+    # Generate subsequences
+    pares = list(combinations(sorted(combination), 2))
+    tercias = list(combinations(sorted(combination), 3))
+    cuartetos = list(combinations(sorted(combination), 4))
+
+    # Get frequency maps
+    freq_map_pares = freqs.get("pares", {})
+    freq_map_tercias = freqs.get("tercias", {})
+    freq_map_cuartetos = freqs.get("cuartetos", {})
+
+    # Build breakdown lists
+    breakdown_pares = [
+        {"subsequence": str(p), "frequency": freq_map_pares.get(p, 0)} for p in pares
+    ]
+    breakdown_tercias = [
+        {"subsequence": str(t), "frequency": freq_map_tercias.get(t, 0)} for t in tercias
+    ]
+    breakdown_cuartetos = [
+        {"subsequence": str(c), "frequency": freq_map_cuartetos.get(c, 0)} for c in cuartetos
+    ]
+
+    # Sort by frequency
+    breakdown_pares.sort(key=lambda x: x["frequency"], reverse=True)
+    breakdown_tercias.sort(key=lambda x: x["frequency"], reverse=True)
+    breakdown_cuartetos.sort(key=lambda x: x["frequency"], reverse=True)
+
+    # Structure the final output
+    deconstructed_data = {
+        "combination": eval_result.get("combinacion"),
+        "omega_score": eval_result.get("omegaScore"),
+        "totals": {
+            "pares": eval_result.get("afinidadPares"),
+            "tercias": eval_result.get("afinidadTercias"),
+            "cuartetos": eval_result.get("afinidadCuartetos"),
+        },
+        "breakdown": {
+            "pares": breakdown_pares,
+            "tercias": breakdown_tercias,
+            "cuartetos": breakdown_cuartetos,
+        },
+        "error": None
+    }
+
+    return deconstructed_data

--- a/modules/presentation.py
+++ b/modules/presentation.py
@@ -123,7 +123,72 @@ def create_registros_view():
     ])
 
 def create_historicos_view():
+    modal_deconstructor = dbc.Modal(
+        [
+            dbc.ModalHeader(dbc.ModalTitle("Deconstructor de Afinidad", id="modal-deconstructor-title")),
+            dbc.ModalBody([
+                html.H5("Combinación Analizada: [ ] | Omega Score: 0.0", id="modal-deconstructor-header"),
+                html.Hr(),
+                dbc.Row([
+                    dbc.Col(html.P(id="summary-cuartetos"), width=4),
+                    dbc.Col(html.P(id="summary-tercias"), width=4),
+                    dbc.Col(html.P(id="summary-pares"), width=4),
+                ], className="text-center mb-3"),
+                dbc.Tabs(
+                    [
+                        dbc.Tab(
+                            dash_table.DataTable(
+                                id='table-cuartetos',
+                                columns=[
+                                    {'name': 'Subsecuencia', 'id': 'subsequence'},
+                                    {'name': 'Frecuencia (Aporte)', 'id': 'frequency'},
+                                ],
+                                style_cell={'textAlign': 'center'},
+                                style_header={'fontWeight': 'bold'},
+                                page_size=15,
+                            ),
+                            label="Cuartetos (15)",
+                        ),
+                        dbc.Tab(
+                            dash_table.DataTable(
+                                id='table-tercias',
+                                columns=[
+                                    {'name': 'Subsecuencia', 'id': 'subsequence'},
+                                    {'name': 'Frecuencia (Aporte)', 'id': 'frequency'},
+                                ],
+                                style_cell={'textAlign': 'center'},
+                                style_header={'fontWeight': 'bold'},
+                                page_size=20,
+                            ),
+                            label="Tercias (20)",
+                        ),
+                        dbc.Tab(
+                            dash_table.DataTable(
+                                id='table-pares',
+                                columns=[
+                                    {'name': 'Subsecuencia', 'id': 'subsequence'},
+                                    {'name': 'Frecuencia (Aporte)', 'id': 'frequency'},
+                                ],
+                                style_cell={'textAlign': 'center'},
+                                style_header={'fontWeight': 'bold'},
+                                page_size=15,
+                            ),
+                            label="Pares (15)",
+                        ),
+                    ]
+                ),
+            ]),
+            dbc.ModalFooter(
+                dbc.Button("Cerrar", id="btn-close-modal", className="ms-auto", n_clicks=0)
+            ),
+        ],
+        id="modal-deconstructor",
+        size="lg",
+        is_open=False,
+    )
+
     return html.Div([
+        modal_deconstructor,
         html.H3("Melate Retro - Registros Históricos", className="text-center text-dark mb-4"),
         dbc.Row(dbc.Col(dbc.Button("Refrescar Datos", id="btn-refresh-historicos", className="mb-3", color="primary", outline=True)), justify="end"),
         dash_table.DataTable(id='table-historicos',
@@ -136,6 +201,7 @@ def create_historicos_view():
                 {'name': 'Omega Score', 'id': 'omega_score', 'type': 'numeric', 'format': {'specifier': '.4f'}},
                 {'name': 'Af. Cuartetos', 'id': 'afinidad_cuartetos'},
                 {'name': 'Af. Tercias', 'id': 'afinidad_tercias'}, {'name': 'Af. Pares', 'id': 'afinidad_pares'},
+                {'name': 'Analizar', 'id': 'analizar', 'presentation': 'markdown'},
             ],
             data=[], page_size=20, sort_action='native', filter_action='native',
             style_cell={'textAlign': 'center', 'minWidth': '80px'},


### PR DESCRIPTION
This commit introduces the "Deconstructor de Afinidad," a new interactive feature for detailed analysis of combinatorial affinity.

Key changes:
- Adds a new "Analizar" column with a clickable icon to the "Visor Históricos" table.
- Implements a modal that opens upon clicking the icon, displaying a full breakdown of a combination's affinity.
- The modal shows total affinity scores and provides three tabs (Cuartetos, Tercias, Pares) with tables detailing each subsequence and its historical frequency.
- Includes a new backend function `deconstruct_affinity` in `omega_logic.py` to perform the analysis.
- Adds new callbacks in `app.py` to manage modal interaction and data population.
- Updates `presentation.py` with the new modal layout and table column.